### PR TITLE
Update features.py for GenSim >= 4

### DIFF
--- a/mol2vec/features.py
+++ b/mol2vec/features.py
@@ -15,6 +15,9 @@ from gensim.models import word2vec
 import timeit
 from joblib import Parallel, delayed
 
+import gensim
+
+GENSIM4 = gensim.__version__ > "4"  # GENSIM4 has some API changes from GENSIM 3
 
 class DfVec(object):
     """
@@ -422,7 +425,10 @@ def sentences2vec(sentences, model, unseen=None):
     -------
     np.array
     """
-    keys = set(model.wv.vocab.keys())
+   if GENSIM4:
+        keys = set(model.wv.key_to_index)
+    else:
+        keys = set(model.wv.vocab.keys())
     vec = []
     if unseen:
         unseen_vec = model.wv.word_vec(unseen)

--- a/mol2vec/features.py
+++ b/mol2vec/features.py
@@ -425,7 +425,7 @@ def sentences2vec(sentences, model, unseen=None):
     -------
     np.array
     """
-   if GENSIM4:
+    if GENSIM4:
         keys = set(model.wv.key_to_index)
     else:
         keys = set(model.wv.vocab.keys())


### PR DESCRIPTION
In Gensim > 4 some of the APIs have changed. Confer with https://github.com/RaRe-Technologies/gensim/wiki/Migrating-from-Gensim-3.x-to-4. This leads to an error in the sentences2vec function. I've updated the Python code to detect which version of GenSim and switch to the correct API call.